### PR TITLE
Allow to pass a custom Bitcoin provider

### DIFF
--- a/src/address/index.ts
+++ b/src/address/index.ts
@@ -1,13 +1,15 @@
 import { createUnsecuredToken, Json } from 'jsontokens';
+import { getDefaultProvider } from '../provider';
 import { GetAddressOptions } from './types';
 
 export const getAddress = async (options: GetAddressOptions) => {
-  const { message, network, purposes } = options.payload;
-  const provider = window.BitcoinProvider;
+  const { getProvider = getDefaultProvider } = options;
+  const provider = await getProvider();
   if (!provider) {
     throw new Error('No Bitcoin Wallet installed');
   }
-  if(!purposes) {
+  const { message, network, purposes } = options.payload;
+  if (!purposes) {
     throw new Error('Address purposes are required');
   }
   try {

--- a/src/address/types.ts
+++ b/src/address/types.ts
@@ -1,4 +1,4 @@
-import { BitcoinNetwork, BitcoinProvider } from '../provider';
+import { BitcoinNetwork, GetBitcoinProviderFunc } from '../provider';
 
 export enum AddressPurposes {
   PAYMENT = 'payment',
@@ -27,7 +27,7 @@ export interface GetAddressResponse {
 }
 
 export interface GetAddressOptions {
-  getProvider?: () => Promise<BitcoinProvider>;
+  getProvider?: GetBitcoinProviderFunc;
   onFinish: (response: GetAddressResponse) => void;
   onCancel: () => void;
   payload: GetAddressPayload;

--- a/src/address/types.ts
+++ b/src/address/types.ts
@@ -1,4 +1,4 @@
-import { BitcoinNetwork } from '../provider';
+import { BitcoinNetwork, BitcoinProvider } from '../provider';
 
 export enum AddressPurposes {
   PAYMENT = 'payment',
@@ -23,10 +23,11 @@ export interface Address {
 }
 
 export interface GetAddressResponse {
-  addresses: Array<Address>
+  addresses: Array<Address>;
 }
 
 export interface GetAddressOptions {
+  getProvider?: () => Promise<BitcoinProvider>;
   onFinish: (response: GetAddressResponse) => void;
   onCancel: () => void;
   payload: GetAddressPayload;

--- a/src/call/index.ts
+++ b/src/call/index.ts
@@ -1,5 +1,5 @@
 import { createUnsecuredToken, Json } from 'jsontokens';
-import { BitcoinNetwork } from '../provider';
+import { BitcoinNetwork, BitcoinProvider, getDefaultProvider } from '../provider';
 
 export interface CallWalletPayload {
   method: string;
@@ -8,6 +8,7 @@ export interface CallWalletPayload {
 }
 
 export interface CallWalletOptions {
+  getProvider?: () => Promise<BitcoinProvider>;
   onFinish: (response: Record<string, any>) => void;
   onCancel: () => void;
   payload: CallWalletPayload;
@@ -19,12 +20,13 @@ export enum CallMethod {
 }
 
 export const callWalletPopup = async (options: CallWalletOptions) => {
-  const provider = window.BitcoinProvider;
-  const { method } = options.payload;
+  const { getProvider = getDefaultProvider } = options;
+  const provider = await getProvider();
   if (!provider) {
     throw new Error('No Bitcoin Wallet installed');
   }
-  if(!method) {
+  const { method } = options.payload;
+  if (!method) {
     throw new Error('A wallet method is required');
   }
   const request = createUnsecuredToken(options.payload as unknown as Json);

--- a/src/call/index.ts
+++ b/src/call/index.ts
@@ -1,5 +1,5 @@
 import { createUnsecuredToken, Json } from 'jsontokens';
-import { BitcoinNetwork, BitcoinProvider, getDefaultProvider } from '../provider';
+import { BitcoinNetwork, GetBitcoinProviderFunc, getDefaultProvider } from '../provider';
 
 export interface CallWalletPayload {
   method: string;
@@ -8,7 +8,7 @@ export interface CallWalletPayload {
 }
 
 export interface CallWalletOptions {
-  getProvider?: () => Promise<BitcoinProvider>;
+  getProvider?: GetBitcoinProviderFunc;
   onFinish: (response: Record<string, any>) => void;
   onCancel: () => void;
   payload: CallWalletPayload;

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -20,6 +20,8 @@ declare global {
   }
 }
 
-export function getDefaultProvider(): BitcoinProvider | undefined {
+export type GetBitcoinProviderFunc = () => Promise<BitcoinProvider | undefined>;
+
+export async function getDefaultProvider(): Promise<BitcoinProvider | undefined> {
   return window.BitcoinProvider;
 }

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -19,3 +19,7 @@ declare global {
     BitcoinProvider?: BitcoinProvider;
   }
 }
+
+export function getDefaultProvider(): BitcoinProvider | undefined {
+  return window.BitcoinProvider;
+}

--- a/src/signatures/index.ts
+++ b/src/signatures/index.ts
@@ -1,21 +1,23 @@
 import { createUnsecuredToken, Json } from 'jsontokens';
+import { getDefaultProvider } from '../provider';
 import { SignMessageOptions } from './types';
 
 export const signMessage = async (options: SignMessageOptions) => {
-  const {address, message} = options.payload;
-  const provider = window.BitcoinProvider;
+  const { getProvider = getDefaultProvider } = options;
+  const provider = await getProvider();
   if (!provider) {
     throw new Error('No Bitcoin Wallet installed');
   }
-  if(!address) {
-    throw new Error("An Address is required to sign a message");
+  const { address, message } = options.payload;
+  if (!address) {
+    throw new Error('An Address is required to sign a message');
   }
   if (!message) {
     throw new Error('you need to provide a message to be signed');
   }
   try {
     const request = createUnsecuredToken(options.payload as unknown as Json);
-    const response  = await provider.signMessage(request);
+    const response = await provider.signMessage(request);
     options.onFinish?.(response);
   } catch (error) {
     console.error('[Connect] Error during Signing request', error);

--- a/src/signatures/types.ts
+++ b/src/signatures/types.ts
@@ -1,4 +1,4 @@
-import { BitcoinNetwork, BitcoinProvider } from '../provider';
+import { BitcoinNetwork, GetBitcoinProviderFunc } from '../provider';
 
 export interface SignMessagePayload {
   address: string;
@@ -7,7 +7,7 @@ export interface SignMessagePayload {
 }
 
 export interface SignMessageOptions {
-  getProvider?: () => Promise<BitcoinProvider>;
+  getProvider?: GetBitcoinProviderFunc;
   onFinish: (response: string) => void;
   onCancel: () => void;
   payload: SignMessagePayload;

--- a/src/signatures/types.ts
+++ b/src/signatures/types.ts
@@ -1,4 +1,4 @@
-import { BitcoinNetwork } from '../provider';
+import { BitcoinNetwork, BitcoinProvider } from '../provider';
 
 export interface SignMessagePayload {
   address: string;
@@ -7,6 +7,7 @@ export interface SignMessagePayload {
 }
 
 export interface SignMessageOptions {
+  getProvider?: () => Promise<BitcoinProvider>;
   onFinish: (response: string) => void;
   onCancel: () => void;
   payload: SignMessagePayload;

--- a/src/transactions/sendBtcTransaction.ts
+++ b/src/transactions/sendBtcTransaction.ts
@@ -1,40 +1,39 @@
 import { createUnsecuredToken, Json } from 'jsontokens';
-import { BitcoinNetwork } from '../provider';
+import { BitcoinNetwork, BitcoinProvider, getDefaultProvider } from '../provider';
 
 export interface SendBtcTransactionPayload {
   network: BitcoinNetwork;
   amountSats: string;
-  recipientAddress: string
+  recipientAddress: string;
   message?: string;
 }
 
 export interface SendBtcTransactionOptions {
-  payload: SendBtcTransactionPayload;
+  getProvider?: () => Promise<BitcoinProvider>;
   onFinish: (response: string) => void;
   onCancel: () => void;
+  payload: SendBtcTransactionPayload;
 }
 
-
 export const sendBtcTransaction = async (options: SendBtcTransactionOptions) => {
-  const { amountSats, recipientAddress } = options.payload;
-  const provider = window.BitcoinProvider;
-
+  const { getProvider = getDefaultProvider } = options;
+  const provider = await getProvider();
   if (!provider) {
     throw new Error('No Bitcoin Wallet installed');
   }
+  const { amountSats, recipientAddress } = options.payload;
   if (!amountSats) {
     throw new Error('a value for amount to be transferred is required');
   }
   if (!recipientAddress) {
     throw new Error('the recipient address is required');
   }
-    try {
-      const request = createUnsecuredToken(options.payload as unknown as Json);
-      const addressResponse = await provider.sendBtcTransaction(request);
-      options.onFinish?.(addressResponse);
-    } catch (error) {
-      console.error('[Connect] Error during send btc request', error);
-      options.onCancel?.();
-    }
+  try {
+    const request = createUnsecuredToken(options.payload as unknown as Json);
+    const addressResponse = await provider.sendBtcTransaction(request);
+    options.onFinish?.(addressResponse);
+  } catch (error) {
+    console.error('[Connect] Error during send btc request', error);
+    options.onCancel?.();
+  }
 };
-

--- a/src/transactions/sendBtcTransaction.ts
+++ b/src/transactions/sendBtcTransaction.ts
@@ -1,5 +1,5 @@
 import { createUnsecuredToken, Json } from 'jsontokens';
-import { BitcoinNetwork, BitcoinProvider, getDefaultProvider } from '../provider';
+import { BitcoinNetwork, GetBitcoinProviderFunc, getDefaultProvider } from '../provider';
 
 export interface SendBtcTransactionPayload {
   network: BitcoinNetwork;
@@ -9,7 +9,7 @@ export interface SendBtcTransactionPayload {
 }
 
 export interface SendBtcTransactionOptions {
-  getProvider?: () => Promise<BitcoinProvider>;
+  getProvider?: GetBitcoinProviderFunc;
   onFinish: (response: string) => void;
   onCancel: () => void;
   payload: SendBtcTransactionPayload;

--- a/src/transactions/signTransaction.ts
+++ b/src/transactions/signTransaction.ts
@@ -1,13 +1,11 @@
 import { createUnsecuredToken, Json } from 'jsontokens';
-import { BitcoinNetwork } from '../provider';
-
+import { BitcoinNetwork, BitcoinProvider, getDefaultProvider } from '../provider';
 
 export interface InputToSign {
-  address: string,
-  signingIndexes: Array<number>,
-  sigHash?: number,
+  address: string;
+  signingIndexes: Array<number>;
+  sigHash?: number;
 }
-
 
 export interface SignTransactionPayload {
   network: BitcoinNetwork;
@@ -18,9 +16,10 @@ export interface SignTransactionPayload {
 }
 
 export interface SignTransactionOptions {
-  payload: SignTransactionPayload;
+  getProvider?: () => Promise<BitcoinProvider>;
   onFinish: (response: any) => void;
   onCancel: () => void;
+  payload: SignTransactionPayload;
 }
 
 export interface SignTransactionResponse {
@@ -28,26 +27,25 @@ export interface SignTransactionResponse {
   txId?: string;
 }
 
-
 export const signTransaction = async (options: SignTransactionOptions) => {
-  const { psbtBase64, inputsToSign } = options.payload;
-  const provider = window.BitcoinProvider;
+  const { getProvider = getDefaultProvider } = options;
+  const provider = await getProvider();
   if (!provider) {
     throw new Error('No Bitcoin Wallet installed');
   }
+  const { psbtBase64, inputsToSign } = options.payload;
   if (!psbtBase64) {
     throw new Error('a value for psbtBase64 representing the tx hash is required');
   }
   if (!inputsToSign) {
     throw new Error('an array specifying the inputs to be signed by the wallet is required');
   }
-    try {
-      const request = createUnsecuredToken(options.payload as unknown as Json);
-      const addressResponse = await provider.signTransaction(request);
-      options.onFinish?.(addressResponse);
-    } catch (error) {
-      console.error('[Connect] Error during signPsbt request', error);
-      options.onCancel?.();
-    }
+  try {
+    const request = createUnsecuredToken(options.payload as unknown as Json);
+    const addressResponse = await provider.signTransaction(request);
+    options.onFinish?.(addressResponse);
+  } catch (error) {
+    console.error('[Connect] Error during signPsbt request', error);
+    options.onCancel?.();
+  }
 };
-

--- a/src/transactions/signTransaction.ts
+++ b/src/transactions/signTransaction.ts
@@ -1,5 +1,5 @@
 import { createUnsecuredToken, Json } from 'jsontokens';
-import { BitcoinNetwork, BitcoinProvider, getDefaultProvider } from '../provider';
+import { BitcoinNetwork, GetBitcoinProviderFunc, getDefaultProvider } from '../provider';
 
 export interface InputToSign {
   address: string;
@@ -16,7 +16,7 @@ export interface SignTransactionPayload {
 }
 
 export interface SignTransactionOptions {
-  getProvider?: () => Promise<BitcoinProvider>;
+  getProvider?: GetBitcoinProviderFunc;
   onFinish: (response: any) => void;
   onCancel: () => void;
   payload: SignTransactionPayload;


### PR DESCRIPTION
## Summary

This PR extends `sats-connect` in a non-breaking way to allow passing a custom `BitcoinProvider` instance, instead of relying on wallets injecting in `window.BitcoinProvider`.

All functions that previously accessed `window.BitcoinProvider` now accept a `getProvider` option. This is an async function that must resolve to a `BitcoinProvider`. If the option is not passed, it defaults to `() => window.BitcoinProvider`.

## Motivation

Injecting in `window.BitcoinProvider` is a bad practice (popularized by MetaMask injecting in `window.ethereum`) which leads to namespace collision and poor UX for people with multiple wallets installed in their browser. Alternative mechanisms for wallet injection and detection are preferable.

[Wallet Standard](https://github.com/wallet-standard/wallet-standard) (and its [Bitcoin extensions](https://github.com/ExodusMovement/bitcoin-wallet-standard)) were created to solve this problem. With this PR, dApps can detect an standard Bitcoin wallet, extract the provider from it and pass in to the `sats-connect` functions.