### PR TITLE
Fix bigInt serialisation Issue

### DIFF
--- a/src/addresses/types.ts
+++ b/src/addresses/types.ts
@@ -1,19 +1,19 @@
 import type { RequestOptions, RequestPayload } from '../types';
 
-export enum AddressPurpose {
+export enum AddressPurposes {
   Ordinals = 'ordinals',
   Payment = 'payment',
 }
 
 export interface GetAddressPayload extends RequestPayload {
-  purposes: AddressPurpose[];
+  purposes: AddressPurposes[];
   message: string;
 }
 
 export interface Address {
   address: string;
   publicKey: string;
-  purpose: AddressPurpose;
+  purpose: AddressPurposes;
 }
 
 export interface GetAddressResponse {

--- a/src/addresses/types.ts
+++ b/src/addresses/types.ts
@@ -1,19 +1,19 @@
 import type { RequestOptions, RequestPayload } from '../types';
 
-export enum AddressPurposes {
+export enum AddressPurpose {
   Ordinals = 'ordinals',
   Payment = 'payment',
 }
 
 export interface GetAddressPayload extends RequestPayload {
-  purposes: AddressPurposes[];
+  purposes: AddressPurpose[];
   message: string;
 }
 
 export interface Address {
   address: string;
   publicKey: string;
-  purpose: AddressPurposes;
+  purpose: AddressPurpose;
 }
 
 export interface GetAddressResponse {

--- a/src/transactions/sendBtcTransaction.ts
+++ b/src/transactions/sendBtcTransaction.ts
@@ -2,7 +2,12 @@ import type { Json } from 'jsontokens';
 import { createUnsecuredToken } from 'jsontokens';
 
 import { getDefaultProvider } from '../provider';
-import type { Recipient, SendBtcTransactionOptions, SerializedRecipient, SerializedSendBtcTransactionPayload } from './types';
+import type {
+  Recipient,
+  SendBtcTransactionOptions,
+  SerializedRecipient,
+  SerializedSendBtcTransactionPayload,
+} from './types';
 
 const serializer = (recipient: Recipient[]): SerializedRecipient[] => {
   return recipient.map((value) => {
@@ -24,6 +29,13 @@ export const sendBtcTransaction = async (options: SendBtcTransactionOptions) => 
   const { recipients, senderAddress, network, message } = options.payload;
   if (!recipients || recipients.length === 0) {
     throw new Error('At least one recipient is required');
+  }
+  if (
+    recipients.some(
+      (item) => typeof item.address !== 'string' || typeof item.amountSats !== 'bigint'
+    )
+  ) {
+    throw new Error('Incorrect recipient format');
   }
   if (!senderAddress) {
     throw new Error('The sender address is required');

--- a/src/transactions/sendBtcTransaction.ts
+++ b/src/transactions/sendBtcTransaction.ts
@@ -31,13 +31,13 @@ export const sendBtcTransaction = async (options: SendBtcTransactionOptions) => 
 
   try {
     const serializedRecipients: SerializedRecipient[] = serializer(recipients);
-    const serialisedPayload: SerializedSendBtcTransactionPayload = {
+    const serializedPayload: SerializedSendBtcTransactionPayload = {
       network,
       senderAddress,
       message,
       recipients: serializedRecipients,
     };
-    const request = createUnsecuredToken(serialisedPayload as unknown as Json);
+    const request = createUnsecuredToken(serializedPayload as unknown as Json);
     const response = await provider.sendBtcTransaction(request);
     options.onFinish?.(response);
   } catch (error) {

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -5,11 +5,19 @@ export interface Recipient {
   amountSats: bigint;
 }
 
+export type SerializedRecipient = Omit<Recipient, 'amountSats'> & {
+  amountSats: string;
+};
+
 export interface SendBtcTransactionPayload extends RequestPayload {
   recipients: Recipient[];
   senderAddress: string;
   message?: string;
 }
+
+export type SerializedSendBtcTransactionPayload = Omit<SendBtcTransactionPayload, 'recipients'> & {
+  recipients: SerializedRecipient[];
+};
 
 export type SendBtcTransactionResponse = string;
 


### PR DESCRIPTION
The type of amountSats is set as bigint but when the bigint value is set for amountSats in recipient array in sats connect example app, an error is thrown `Donot know how to serialize a BigInt`. 
The reason for this is BigInt value will raise a TypeError if called in `JSON.stringify`, as BigInt values aren't serialized . 
For more context, see the official documentation: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#operators
The `JSON.stringify` is called in function `createUnsecuredToken` and throws the error.

The PR fixes this issue by serialising the recipient array so that the payload can be sent to `createUnsecuredToken` and then further in the extension and app. 
The PR also adds type validation for recipient array

**For testing**
Extension PR: https://github.com/secretkeylabs/xverse-web-extension/pull/543
                        https://github.com/secretkeylabs/xverse-web-extension/pull/546
Sats Connect Example PR: https://github.com/secretkeylabs/sats-connect-example/pull/8
Test the send BTC function with different values for the recipient array by changing the amountSats value to number, decimal and then bigint. It should only work for bigint. 
Also play around with the recipient type by changing from string to see if the error `Incorrect recipient format`comes up. 
You can make changes to the values of address and amountSats by making changes in the recipient object on line https://github.com/secretkeylabs/sats-connect-example/blob/3ff09d43b7e9523d1552ed2d12b125ac918b15d5/src/dashboard.js#L197 in the test app