### PR TITLE
chore: npm publish with prerelease tag if prerelease option selected

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -2,7 +2,7 @@ name: Release & Publish Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build:
@@ -29,6 +29,11 @@ jobs:
           registry-url: https://registry.npmjs.org
       - run: npm ci
       - run: npm run build
+      - run: npm publish --tag prerelease
+        if: github.event.release.prerelease
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - run: npm publish
+        if: !github.event.release.prerelease
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
type:
- CI only

changes:
- trigger on "published" not "created": this will listen for any release either published from new or draft
- publish with a tag prerelease if prerelease option was ticked
- else publish with tag latest if preprelease option was not ticked

ref: 
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
- https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release

test with:
- `npm dist-tags ls`
