### PR TITLE
chore: fix file path ref in import statement

### DIFF
--- a/src/capabilities/types.ts
+++ b/src/capabilities/types.ts
@@ -1,4 +1,4 @@
-import type { Capability } from 'src/provider';
+import type { Capability } from '../provider';
 import type { RequestOptions, RequestPayload } from '../types';
 
 export interface GetCapabilitiesPayload extends RequestPayload {}


### PR DESCRIPTION
**Description:** 
when a typescript project with sats-connect as a dependency is being built by `tsc` getting below error
```
node_modules/sats-connect/dist/capabilities/types.d.ts:1:33 - error TS2307: Cannot find module 'src/provider' or its corresponding type declarations.

1 import type { Capability } from 'src/provider';
                                  ~~~~~~~~~~~~~~


Found 1 error in node_modules/sats-connect/dist/capabilities/types.d.ts:1
```

Changes:
- fix import statement file path format.


