### PR TITLE
Fix typing to allow better merging of interfaces

### DIFF
--- a/src/provider/types.ts
+++ b/src/provider/types.ts
@@ -27,10 +27,12 @@ export interface BitcoinProvider extends BaseBitcoinProvider {
 }
 
 declare global {
+  interface XverseProviders {
+    BitcoinProvider?: BitcoinProvider;
+  }
+
   interface Window {
     BitcoinProvider?: BitcoinProvider;
-    XverseProviders?:{
-      BitcoinProvider?: BitcoinProvider;
-    }
+    XverseProviders?: XverseProviders
   }
 }


### PR DESCRIPTION
Extracting the XverseProviders into its own interface allows it to be extended instead of being static on the window interface.