### PR TITLE
chore: remove -rc tags step and add a step to add dist-tag latest

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -2,7 +2,7 @@ name: Release & Publish Package
 
 on:
   release:
-    types: [published]
+    types: [published, released, prereleased]
 
 jobs:
   build:
@@ -29,16 +29,21 @@ jobs:
           registry-url: https://registry.npmjs.org
       - run: npm ci
       - run: npm run build
-      - id: use-tag-version
-        if: github.event.release.prerelease
-        continue-on-error: true
-        run: npm version --no-git-tag-version $(git describe --tags --abbrev=0 | sed 's/^v//')
       - id: publish-prerelease
         if: github.event.release.prerelease
         run: npm publish --tag prerelease
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - run: npm publish
-        if: '!github.event.release.prerelease'
+      - id: npm-publish-latest
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        continue-on-error: true
+        run: npm publish
+      - id: set-dist-tag-latest
+        needs: npm-publish-latest
+        if: ${{steps.npm-publish-latest.outcome.failure}}
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        run: |
+          VERSION=$(npm pkg get version | jq . -r)
+          npm dist-tag add sats-connect@$VERSION latest


### PR DESCRIPTION
changes:
  - workflow changes only
  - remove the workflow step which would create rc npm package releases
  - add a workflow step which adds the current version to dist-tags latest

impact:
- this allows a sats-connect release to be created as a pre-release first, and then later released with the dist-tag 'latest', so that it becomes the default version for someone using `npm i sats-connect`
- previously the workflow would not run again, when a release is changed from 'pre-release' to 'latest'