### PR TITLE
Proposed typing for the result

### DIFF
--- a/src/request/index.ts
+++ b/src/request/index.ts
@@ -1,5 +1,5 @@
 import { getProviderById } from '../provider';
-import { RpcBase, RpcErrorCode, RpcResult, RpcSuccessResponse } from '../types';
+import { RpcBase, RpcResult, RpcSuccessResponse } from '../types';
 import { Params, Requests } from './types';
 
 export const request = async <Method extends keyof Requests>(
@@ -24,12 +24,6 @@ export const request = async <Method extends keyof Requests>(
     return {
       status: 'success',
       result: response.result,
-    };
-  }
-
-  if (response.error.code === RpcErrorCode.USER_REJECTION) {
-    return {
-      status: 'cancelled',
     };
   }
 

--- a/src/request/index.ts
+++ b/src/request/index.ts
@@ -1,12 +1,12 @@
-import { RpcResponse, RpcSuccessResponse } from '../types';
 import { getProviderById } from '../provider';
+import { RpcBase, RpcErrorCode, RpcResult, RpcSuccessResponse } from '../types';
 import { Params, Requests } from './types';
 
 export const request = async <Method extends keyof Requests>(
   method: Method,
   params: Params<Method>,
   providerId?: string
-): Promise<RpcResponse<Method>> => {
+): Promise<RpcResult<Method>> => {
   let provider = window.XverseProviders?.BitcoinProvider || window.BitcoinProvider;
   if (providerId) {
     provider = await getProviderById(providerId);
@@ -18,13 +18,31 @@ export const request = async <Method extends keyof Requests>(
     throw new Error('A wallet method is required');
   }
 
-  return provider.request(method, params);
+  const response = await provider.request(method, params);
+
+  if (isRpcSuccessResponse<Method>(response)) {
+    return {
+      status: 'success',
+      result: response.result,
+    };
+  }
+
+  if (response.error.code === RpcErrorCode.USER_REJECTION) {
+    return {
+      status: 'cancelled',
+    };
+  }
+
+  return {
+    status: 'error',
+    error: response.error,
+  };
 };
 
-export const isRpcSuccessResponse = <Method extends keyof Requests>(
-  response: RpcResponse<Method>
+const isRpcSuccessResponse = <Method extends keyof Requests>(
+  response: RpcBase
 ): response is RpcSuccessResponse<Method> => {
-  return Object.hasOwn(response, 'result');
+  return Object.hasOwn(response, 'result') && !!(response as RpcSuccessResponse<Method>).result;
 };
 
 export * from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,7 +103,4 @@ export type RpcResult<Method extends keyof Requests> =
   | {
       error: RpcErrorResponse['error'];
       status: 'error';
-    }
-  | {
-      status: 'cancelled';
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,3 +94,16 @@ export interface RpcSuccessResponse<Method extends keyof Requests> extends RpcBa
 export type RpcResponse<Method extends keyof Requests> =
   | RpcSuccessResponse<Method>
   | RpcErrorResponse;
+
+export type RpcResult<Method extends keyof Requests> =
+  | {
+      result: RpcSuccessResponse<Method>['result'];
+      status: 'success';
+    }
+  | {
+      error: RpcErrorResponse['error'];
+      status: 'error';
+    }
+  | {
+      status: 'cancelled';
+    };


### PR DESCRIPTION
This is an alternative typing for the result of the request function. It allows you to do the below:
```typescript
const getAddresses = async () => {
  const response = await request('getAddresses', { purposes: [AddressPurpose.Payment] });

  switch (response.status) {
    case 'success':
      // do success stuff here. Typescript knows that response.result exists because of the status value of success
      console.log('Addresses', response.result);
      break;
    case 'error':
      // Typecript sees result.error as existing below because the status matches the type
      console.log('Error', response.error);
      break;
    case 'cancelled':
    default:
      // Typescript knows that response.status is cancelled here
      console.log('User cancelled');
      /* below 2 lines would show a typescript error because they don't exist on the cancelled type
      response.error;
      response.result;
      */
      break;
  }
};
```

For a more direct example, this is the current:
```typescript
const getAddresses = async () => {
  const response = await request('getAddresses', { purposes: [AddressPurpose.Payment] });

  if(isRpcSuccessResponse(response)) {
    console.log('Addresses', response.result);
    return
  }

  if(response.error.code === RpcErrorCode.USER_REJECTION) {
    console.log('User cancelled');
    return
  }

  console.log('Error', response.error);
}
```

This would be the new without the need for the helper function and digging into the error codes for cancel:
```typescript
const getAddresses = async () => {
  const response = await request('getAddresses', { purposes: [AddressPurpose.Payment] });

  if(response.status === 'success') {
    console.log('Addresses', response.result);
    return
  }

  if(response.status === 'cancelled') {
    console.log('User cancelled');
    return
  }

  console.log('Error', response.error);
}
```

Also, the user won't have the json RPC version and event ID available in the new result because they don't really need them. In that way, Sats-connect becomes like a friendlier wrapper of the RPC protocol while the actual comms are done with JSON RPC and if devs want to go lower level, they can communicate with the provider directly.

Also, it's not required to import additional helper functions to see if the response is a success and to type it appropriately.