### PR TITLE
create abstracted connect RPC method

### DIFF
--- a/src/request/types/btcMethods.ts
+++ b/src/request/types/btcMethods.ts
@@ -123,3 +123,7 @@ export type SignPsbtResult = {
 };
 
 export type SignPsbt = MethodParamsAndResult<SignPsbtParams, SignPsbtResult>;
+
+export type GetAccountResult = Address[] | Record<string, string> | string[];
+
+export type GetAccounts = MethodParamsAndResult<null, GetAccountResult>;

--- a/src/request/types/btcMethods.ts
+++ b/src/request/types/btcMethods.ts
@@ -124,6 +124,6 @@ export type SignPsbtResult = {
 
 export type SignPsbt = MethodParamsAndResult<SignPsbtParams, SignPsbtResult>;
 
-export type GetAccountResult = Address[] | Record<string, string> | string[];
+export type GetAccountResult = Address[];
 
 export type GetAccounts = MethodParamsAndResult<null, GetAccountResult>;

--- a/src/request/types/index.ts
+++ b/src/request/types/index.ts
@@ -1,5 +1,11 @@
-import { RpcSuccessResponse } from 'src/types';
-import { GetAddresses, GetInfo, SendTransfer, SignMessage, SignPsbt } from './btcMethods';
+import {
+  GetAccounts,
+  GetAddresses,
+  GetInfo,
+  SendTransfer,
+  SignMessage,
+  SignPsbt,
+} from './btcMethods';
 import {
   StxCallContract,
   StxDeployContract,
@@ -27,6 +33,7 @@ export type StxRequestMethod = keyof StxRequests;
 export interface BtcRequests {
   getInfo: GetInfo;
   getAddresses: GetAddresses;
+  getAccounts: GetAccounts;
   signMessage: SignMessage;
   sendTransfer: SendTransfer;
   signPsbt: SignPsbt;


### PR DESCRIPTION
This PR adds support for the `getAccounts` method
API: 
```
params: none 
returns Address[]
```

with the address being an object with the following parameters 
```
  address: string;
  publicKey: string;
  purpose: AddressPurpose;
  addressType?: AddressType;
```

the number of addresses returned will be different depending on how many bitcoin/ l2 addresses the user wallet supports 