### PR TITLE
chore: fix mark as latest

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -37,7 +37,6 @@ jobs:
       - id: npm-publish-latest
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        continue-on-error: true
         run: npm publish
       - id: set-dist-tag-latest
         if: ${{steps.npm-publish-latest.outcome.failure}}


### PR DESCRIPTION
problem was continue-on-error would mark the job as success, when we want to run the next step only on failure