### PR TITLE
feat: Bump sats-connect-core to enable versioning [ENG-8026]

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -49,7 +49,7 @@
       "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
-        "@sats-connect/core": "0.8.0",
+        "@sats-connect/core": "^0.8.1-a6a42ae",
         "@sats-connect/make-default-provider-config": "0.0.10",
         "@sats-connect/ui": "0.0.7",
         "valibot": "1.1.0"

--- a/example/src/components/spark/GetAddresses/index.tsx
+++ b/example/src/components/spark/GetAddresses/index.tsx
@@ -27,6 +27,8 @@ export const SparkGetAddresses = () => {
         <div key={a.address}>
           <div>Address {i + 1}</div>
           <div>{a.address}</div>
+          <div>Public Key</div>
+          <div>{a.publicKey}</div>
         </div>
       ))}
       <Button onClick={onClick}>Call spark_getAddresses</Button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
-        "@sats-connect/core": "0.8.0",
+        "@sats-connect/core": "^0.8.1-a6a42ae",
         "@sats-connect/make-default-provider-config": "0.0.10",
         "@sats-connect/ui": "0.0.7",
         "valibot": "1.1.0"
@@ -1867,12 +1867,12 @@
       ]
     },
     "node_modules/@sats-connect/core": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@sats-connect/core/-/core-0.8.0.tgz",
-      "integrity": "sha512-XKuvl+O93D2ruZXUoQkW9RPoAO5e/ufdWAhi8FKHmP3L9PZ4CFC40BnkSrHtP9DweMCoYN7POGuIsVTx+RWj0g==",
+      "version": "0.8.1-a6a42ae",
+      "resolved": "https://registry.npmjs.org/@sats-connect/core/-/core-0.8.1-a6a42ae.tgz",
+      "integrity": "sha512-3/GwWClXmDHhwKXeOQdlzcPiSY6/1ztC7W0RNIaARlvftjoqJSSk6MHCcBqgITLyTZ4ulijMunvqN4NNEGNBmw==",
       "license": "ISC",
       "dependencies": {
-        "axios": "1.11.0",
+        "axios": "1.12.0",
         "bitcoin-address-validation": "3.0.0",
         "buffer": "6.0.3",
         "jsontokens": "4.0.1"
@@ -2214,9 +2214,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
+      "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     ]
   },
   "dependencies": {
-    "@sats-connect/core": "0.8.0",
+    "@sats-connect/core": "^0.8.1-a6a42ae",
     "@sats-connect/make-default-provider-config": "0.0.10",
     "@sats-connect/ui": "0.0.7",
     "valibot": "1.1.0"


### PR DESCRIPTION
NOTE: Depends on [this PR](https://github.com/secretkeylabs/sats-connect-core/pull/98)

Bumps sats-connect to newest version where provider versioning is added to handle compatibility issues with older versions of the provider.