### PR TITLE
chore: remove CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @secretkeylabs/code-owners-sats-connect


### PR DESCRIPTION
Remove CODEOWNERS file to avoid notification overflow.