### PR TITLE
ci: use pre-release info action in PR workflow

### DIFF
--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -71,34 +71,10 @@ jobs:
         env:
           VERSION: ${{ steps.published-version.outputs.version }}
 
-      - name: Delete old bot comments
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_ID: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          curl \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            https://api.github.com/repos/$REPO/issues/$PR_ID/comments \
-          | jq ".[] | select(.user.login==\"github-actions[bot]\") | .id" \
-          | xargs -I %q curl \
-            -L \
-            -X DELETE \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token $GITHUB_TOKEN"\
-            https://api.github.com/repos/$REPO/issues/comments/%q
-      - name: Post test package PR comment
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          VERSION: ${{ steps.published-version.outputs.version }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_URL: ${{ github.event.pull_request.comments_url }}
-        run: |
-          curl \
-            -X POST \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            $GITHUB_URL \
-            -d "{\"body\":\"> Test this PR with \`npm i --save-exact sats-connect@$VERSION\`\"}"
+      - name: Add package pre-release info
+        uses: secretkeylabs/github-actions/add-package-pre-release-info-to-pr@main
+        with:
+          package-name: "sats-connect"
+          version: ${{ steps.published-version.outputs.version }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
<!-- package-pre-release-info-start -->
### Package pre-release info

```bash
npm install sats-connect@4.2.1-ab95b1b -E
```

```bash
bun install sats-connect@4.2.1-ab95b1b -E
```

---
<!-- package-pre-release-info-end -->

Replace the manual curl-based "Delete old bot comments" and "Post test package PR comment" steps with the `secretkeylabs/github-actions/add-package-pre-release-info-to-pr@main` action, which handles adding pre-release package version info to the PR body.